### PR TITLE
Add makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+st
+
 # Prerequisites
 *.d
 

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ ST_CPPFLAGS = -I code/include
 prefix = /usr/local
 bindir = $(prefix)/bin
 
-st-sources = $(wildcard code/src/*.cpp)
+st-sources = code/src/main.cpp code/src/netlink.cpp code/src/output.cpp code/src/utils.cpp code/src/proc.cpp code/src/track.cpp
 st-objs = $(st-sources:.cpp=.o)
 
 .PHONY: all install clean

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,25 @@
+CXXFLAGS ?= -O3
+ST_CXXFLAGS = -std=c++2a -Wall -Wextra
+ST_CPPFLAGS = -I code/include
+
+prefix = /usr/local
+bindir = $(prefix)/bin
+
+.PHONY: all install clean
+
+all: st
+
+.cpp.o:
+	$(CXX) $(CXXFLAGS) $(ST_CXXFLAGS) $(ST_CPPFLAGS) -c $< -o $@
+
+st-sources = $(wildcard code/src/*.cpp)
+st-objs = $(st-sources:.cpp=.o)
+st: $(st-objs)
+	$(CXX) $(LDFLAGS) -o $@ $(st-objs)
+
+install: all
+	mkdir -p $(DESTDIR)$(bindir)
+	cp -p st $(DESTDIR)$(bindir)
+
+clean:
+	rm -f $(st-objs) st

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,9 @@ ST_CPPFLAGS = -I code/include
 prefix = /usr/local
 bindir = $(prefix)/bin
 
+st-sources = $(wildcard code/src/*.cpp)
+st-objs = $(st-sources:.cpp=.o)
+
 .PHONY: all install clean
 
 all: st
@@ -12,8 +15,6 @@ all: st
 .cpp.o:
 	$(CXX) $(CXXFLAGS) $(ST_CXXFLAGS) $(ST_CPPFLAGS) -c $< -o $@
 
-st-sources = $(wildcard code/src/*.cpp)
-st-objs = $(st-sources:.cpp=.o)
 st: $(st-objs)
 	$(CXX) $(LDFLAGS) -o $@ $(st-objs)
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-CXXFLAGS ?= -O3 -Wall -Wextra
+CXXFLAGS ?= -O3 -Wall -Wextra -Wshadow -pedantic
 ST_CXXFLAGS = -std=c++2a
 ST_CPPFLAGS = -I code/include
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-CXXFLAGS ?= -O3
-ST_CXXFLAGS = -std=c++2a -Wall -Wextra
+CXXFLAGS ?= -O3 -Wall -Wextra
+ST_CXXFLAGS = -std=c++2a
 ST_CPPFLAGS = -I code/include
 
 prefix = /usr/local

--- a/README.md
+++ b/README.md
@@ -40,3 +40,19 @@ Walltime: 221ms - user-space: 136ms - kernel-space: 69ms
 0MB┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
    0ms                                                                                 221
 ```
+
+
+## Installation
+
+Release build:
+
+```
+make
+make install prefix=<prefix>
+```
+
+For debug builds, specify `CXXFLAGS` and `LDFLAGS` before running make:
+
+```
+export CXXFLAGS="-Og -fsanitize=memory" LDFLAGS=-fsanitize=address
+```

--- a/debug.sh
+++ b/debug.sh
@@ -1,1 +1,0 @@
-clang++ -fsanitize=address --std=c++2a -O3 -o st -I code/include code/src/main.cpp code/src/netlink.cpp code/src/output.cpp code/src/proc.cpp code/src/track.cpp code/src/utils.cpp

--- a/make.sh
+++ b/make.sh
@@ -1,1 +1,0 @@
-clang++ --std=c++2a -O3 -o st -I code/include code/src/main.cpp code/src/netlink.cpp code/src/output.cpp code/src/proc.cpp code/src/track.cpp code/src/utils.cpp


### PR DESCRIPTION
Basic makefile, so you can install:

```
make -j $(nproc)
make install prefix=/somewhere
```

And do "debug" builds by just passing the relevant [cxx/ld]flags:

```
make CXXFLAGS=-fsanitize=address LDFLAGS=-fsanitize=address
```

contributing this cause the shell script hard codes the compiler name.

I've added -Wall and friends by default, notice that the compiler complains about a few unused variables and (un)signed integer related comparisons.