### PR TITLE
Include unistd.h

### DIFF
--- a/code/src/utils.cpp
+++ b/code/src/utils.cpp
@@ -1,6 +1,7 @@
 #include "utils.h"
 
 #include <stdint.h>
+#include <unistd.h>
 #include <ctime>
 #include <cstdarg>
 #include <cstdio>


### PR DESCRIPTION
Fixes build errors due to undeclared getuid, getgid, setgid, setuid, and seteuid functions.

Resolves #3 