### PR TITLE
Makefile: fix reference to st

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-st
+ste
 
 # Prerequisites
 *.d

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ ste: $(st-objs)
 
 install: all
 	mkdir -p $(DESTDIR)$(bindir)
-	cp -p st $(DESTDIR)$(bindir)
+	cp -p ste $(DESTDIR)$(bindir)
 
 clean:
 	rm -f $(st-objs) ste


### PR DESCRIPTION
There is one reference left to `st` in Makefile after https://github.com/fabiensanglard/st/commit/8edc6f17de53fe46657c85ed60268d7f1ab138fb.

Related to fixing issue #2.
See https://github.com/fabiensanglard/st/issues/2#issuecomment-1738406506 for context.