### PR TITLE
readme: fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,5 +54,5 @@ make install prefix=<prefix>
 For debug builds, specify `CXXFLAGS` and `LDFLAGS` before running make:
 
 ```
-export CXXFLAGS="-Og -fsanitize=memory" LDFLAGS=-fsanitize=address
+export CXXFLAGS="-Og -fsanitize=address" LDFLAGS=-fsanitize=address
 ```


### PR DESCRIPTION
sanitizer flags weren't in sync
