### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,15 +44,69 @@ Walltime: 221ms - user-space: 136ms - kernel-space: 69ms
 
 ## Installation
 
+Check your g++ version. If you are running "old" versions (gcc7 etc. is the standard on may distros), you will get compile time errors, and the solution suggested by the compiler (eg. use ST_CXXFLAGS = -std=c++11 in your Makefile) will cause further errors. Because the code uses constructs like std::map::contains(), you need >= C++20, so option C++11 will fail. The the Makefile calls for C++2a, which is fine.
+The solution is to install addtional gcc packages (in parallel), and then use alternatives to manage the versions for compatibility.
+For example, on OpenSUSE:
+```
+> which g++
+/usr/bin/g++
+> zypper install gcc11 gcc11-c++
+> alternatives --install /usr/bin/g++ g++ /usr/bin/g++-11 1
+> alternatives --install /usr/bin/g++ g++ /usr/bin/g++-7 99
+```
+Then select to use g++-11 for the build, without disturbing your default (in our example, g++-7)
+```
+> update-alternatives --config g++
+There are 2 choices for the alternative g++ (providing /usr/bin/g++).
+
+  Selection    Path             Priority   Status
+------------------------------------------------------------
+* 0            /usr/bin/g++-7    99        auto mode
+  1            /usr/bin/g++-11   1         manual mode
+  2            /usr/bin/g++-7    99        manual mode
+
+Press <enter> to keep the current choice[*], or type selection number: 1   
+update-alternatives: using /usr/bin/g++-11 to provide /usr/bin/g++ (g++) in manual mode
+```
+The solution on Ubuntu and other Deb-based distributions is similar:
+Run the following command to add the Toolchain repository:
+```
+> sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+```
+Install gcc 11:
+```
+> sudo apt install -y gcc-11
+```
+Check gcc version to verify that the installation completed successfully:
+```
+> gcc-11 --version
+```
+Then use update-alternatives with the same result as with OpenSUSE above:
+```
+> sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-11 1
+> sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-7 99
+
+```
+
 Release build:
 
 ```
-make
-make install prefix=<prefix>
+> make
+> make install prefix=<prefix>
 ```
+You can specify a directory <prefix> (being the root directory that you wish to install the binary into, eg. "/usr/local").
+The Makefile will append "/bin" to the prefix, to get the full install directory for the "ste" binary (eg. /usr/local/bin)
+
+Uninstall:
+```
+> make uninstall prefix=<prefix>
+```
+Specify the same prefix as you used to install. You will be prompted to confirm deleting the binary.
+NB! The "bin" directory will remain. You can mod the Makefile to also do a rmdir, which will fail safe if the bin directory contains other files.
 
 For debug builds, specify `CXXFLAGS` and `LDFLAGS` before running make:
 
 ```
 export CXXFLAGS="-Og -fsanitize=address" LDFLAGS=-fsanitize=address
 ```
+And yes, CXXFLAGS is correct, being the flags for the C++ compiler. CFLAGS is for the C compiler, and CPPFLAGS is for the C preprocessor.


### PR DESCRIPTION
Hi there. Cherry-pick what you want?
Added details regards the gcc compiler that is required to work with >= C++20 (i.e. C++2a as per Makefile). Eg. I had to install gcc11, as my OpenSUSE 15.5 had gcc7 standard, which was fine for my stuff. But I needed gcc11.
Added uninstall to Makefile.
Some additional comments to explain, eg. CXXFLAGS.